### PR TITLE
Fix output file cut-off issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,17 +65,17 @@ var HtmlReporter = function(baseReporterDecorator, config, emitter, logger, help
 					} else {
 						log.debug('HTML report written to "%s".', reportFile);
 					}
-
-
 				});
+
+				writeStream.on('finish', function() {
+					if (!--pendingFileWritings) {
+						fileWritingFinished();
+					}
+					template = null;
+				});
+
 				template.pipe(writeStream);
 				template.resume();
-			});
-			template.on("end", function() {
-				if (!--pendingFileWritings) {
-					fileWritingFinished();
-				}
-				template = null;
 			});
 
 		});


### PR DESCRIPTION
Fixes: https://github.com/dtabuenc/karma-html-reporter/issues/1

Since it was listening to the template end event instead of the write stream finish event, it could exist before the last file finished writing, leaving it cut off.
