### PR TITLE
Allow custom sub directory for report.

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,10 +53,9 @@ var HtmlReporter = function(baseReporterDecorator, config, emitter, logger, help
 			var outputDir = config.outputDir || 'karma_html';
 			var templatePath = config.templatePath || __dirname + "/jasmine_template.html";
 			var template = mu.compileAndRender(templatePath, results);
-			var middlePathName = config.middlePathDir || results.browserName;
 			template.pause();
-			var reportFile = outputDir + '/' + middlePathName + '/index.html';
-			var writeStream;
+            var reportFile = outputDir + '/' + (config.middlePathDir == null ? results.browserName + '/' : '') + 'index.html';
+            var writeStream;
 			helper.mkdirIfNotExists(path.dirname(reportFile), function() {
 
 				writeStream = fs.createWriteStream(reportFile, function(err) {


### PR DESCRIPTION
This a great tool for creating reports from Karma. I encountered an issue with Jenkins HTML publish where I needed to specify the actual directory of the report. The karma junit reporter allows a sub directory to be specified so I have made a change that allows the same thing using the middlePathDir config property.