### PR TITLE
use fullName as key for suites instead of [].join()

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,10 +186,13 @@ var HtmlReporter = function(baseReporterDecorator, config, emitter, logger, help
 		}
 
 		var suiteKey = result.suite.join(" ");
+		// try using full name of suite as key
+                if ( _.isArray(result.suite) && result.suite.length && result.suite[result.suite.length-1].fullName ) {
+			var suiteKey = result.suite[result.suite.length-1].fullName;
+                }
 		if (suites[suiteKey] === undefined) {
 			return suites[suiteKey] = { specs : [] };
-		}
-		else {
+		} else {
 			return suites[suiteKey];
 		}
 	}


### PR DESCRIPTION
So I have been struggling with why all I see in the name is [object Object] and have found that the suiteKey is using the result.suite.join which is an array of objects.  This ends up in the UI doing weird things.  So after several tries this fixes that issue and the html template ends up with the correct name for the suites.  