### PR TITLE
Build outputDir using Karma's configuration basePath.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var _ = require('lodash');
 var mu = require('mu2');
 
 
-var HtmlReporter = function(baseReporterDecorator, config, emitter, logger, helper, formatError) {
+var HtmlReporter = function(baseReporterDecorator, basePath, config, emitter, logger, helper, formatError) {
 	config = config || {};
 	var pkgName = config.suite;
 	var log = logger.create('reporter.html');
@@ -36,13 +36,13 @@ var HtmlReporter = function(baseReporterDecorator, config, emitter, logger, help
 			timestamp : timestamp,
 			hostname : os.hostname(),
 			suites : {},
-			sections: null, // for preserveDescribeNesting
+			sections: null // for preserveDescribeNesting
 		};
 		
 		env[browser.id] = { // preserveDescribeNesting stuff
 			currentSuiteName: [], // current set of `describe` names as an array of strings
 			currentIndent: 0, // in 'levels'
-			sectionIndex: -1, // current top-level `describe` in processing 
+			sectionIndex: -1 // current top-level `describe` in processing
 		};
 	};
 
@@ -71,7 +71,7 @@ var HtmlReporter = function(baseReporterDecorator, config, emitter, logger, help
 			// whether to select the Failures tab automatically 
 			results.focusOnFailures = config.focusOnFailures !== false && results.results.hasFailed;
 			
-			var outputDir = config.outputDir || 'karma_html';
+			var outputDir = path.resolve(basePath, config.outputDir || 'karma_html');
 			var reportName = config.reportName || config.middlePathDir || results.browserName;
 			results.pageTitle = config.pageTitle || reportName; // inject into head 
 			if (config.urlFriendlyName) reportName = reportName.replace(/ /g, '_');
@@ -155,7 +155,7 @@ var HtmlReporter = function(baseReporterDecorator, config, emitter, logger, help
 					sections[e.sectionIndex].lines.push({ // `describe` line
 						className: 'description'+ (!e.currentIndent ? ' section-starter' : ' br'),
 						style: 'margin-left:'+ (e.currentIndent * 14) + 'px',
-						value: result.suite[e.currentIndent],
+						value: result.suite[e.currentIndent]
 					});
 					describeAdded = true;
 				}
@@ -171,7 +171,7 @@ var HtmlReporter = function(baseReporterDecorator, config, emitter, logger, help
 				sections[e.sectionIndex].lines.push({ // `describe` line
 					className: 'description section-starter',
 					style: 'margin-left:'+ (e.currentIndent * 14) + 'px',
-					value: 'Anonymous Suite',
+					value: 'Anonymous Suite'
 				});
 				e.currentIndent = 1;
 			}
@@ -180,7 +180,7 @@ var HtmlReporter = function(baseReporterDecorator, config, emitter, logger, help
 									 (result.skipped ? 'skipped' : result.success ? 'passed' : 'failed') +
 									 (e.currentIndent < lastIndent && !describeAdded ? ' br' : ''),
 				style: 'margin-left:'+ (e.currentIndent * 14) + 'px',
-				value: result.description,
+				value: result.description
 			});
 			sections[e.sectionIndex][result.skipped ? 'skipped' : result.success ? 'passed' : 'failed']++;
 		}
@@ -203,7 +203,7 @@ var HtmlReporter = function(baseReporterDecorator, config, emitter, logger, help
 				for (n = 0; n < k.length; n++) {
 					if (browser.sections[i][ k[n] ]) browser.sections[i].lines[0].totals.push({
 						result: k[n],
-						count: browser.sections[i][ k[n] ],
+						count: browser.sections[i][ k[n] ]
 					});
 				}
 			}
@@ -272,7 +272,7 @@ var HtmlReporter = function(baseReporterDecorator, config, emitter, logger, help
 
 };
 
-HtmlReporter.$inject = ['baseReporterDecorator', 'config.htmlReporter', 'emitter', 'logger', 'helper', 'formatError'];
+HtmlReporter.$inject = ['baseReporterDecorator', 'config.basePath', 'config.htmlReporter', 'emitter', 'logger', 'helper', 'formatError'];
 
 // PUBLISH DI MODULE
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-html-reporter",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "A Karma plugin. Report results in pretty html format.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When the Karma configuration file sits somewhere other than the root of the project, it is useful to make use of the basePath configuration property. However, the HTML reporter was not making use of this, unlike the Coverage reporter, for example. Running from the terminal or from WebStorm's Karma plugin was creating the HTML reports folder in two different places.