### PR TITLE
Decrement pendingFileWritings if browserResult undefined.

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,10 @@ var HtmlReporter = function(baseReporterDecorator, config, emitter, logger, help
 		browsers.forEach(function(browser) {
 			var results = browserResults[browser.id];
 
-			if(results == undefined){
+			if (results == undefined) {
+				if (!--pendingFileWritings) {
+					fileWritingFinished();
+				}
 				return;
 			}
 			prepareResults(results);


### PR DESCRIPTION
When the karma test units encountered a script error at the start of a test run, onRunComplete was called, but browserResults[browser.id] was undefined.  It would return early, preventing a crash, but never decrement pendingFileWritings, which would cause karma to hang indefinitely and never call done.