### PR TITLE
Fix for supporting source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,6 +113,7 @@ var HtmlReporter = function(baseReporterDecorator, config, emitter, logger, help
 
 	this.specSuccess = this.specSkipped = this.specFailure = function(browser, result) {
 		var suite = getOrCreateSuite(browser, result);
+        	result.log = _.map(result.log, formatError);
 		suite.specs.push(result);
 	};
 


### PR DESCRIPTION
Took me a while to figure this out, but this reporters log outputs didn't match what was being reported to the console or to my junit reports. The "formatError" function was not being utilized in this report, so I preprocess the logs by running them thru the formatter before it reaches the templates. Now the templates show the formatted error log, which will include post processing to map lines/columns in source files back to source maps, if used. 

Without this change, if source maps are used, they will not be displayed in the report which makes debugging difficult.